### PR TITLE
fix(prototyper): add sfence.vma flush range limit

### DIFF
--- a/prototyper/src/trap.rs
+++ b/prototyper/src/trap.rs
@@ -15,8 +15,8 @@ use crate::rfence::{local_rfence, RFenceType};
 use crate::riscv_spec::{CSR_TIME, CSR_TIMEH, current_hartid};
 
 const PAGE_SIZE: usize = 4096;
-// TODO: `TLB_FLUASH_LIMIT` is a platform-dependent parameter
-const TLB_FLUASH_LIMIT: usize = 4 * PAGE_SIZE;
+// TODO: `TLB_FLUSH_LIMIT` is a platform-dependent parameter
+const TLB_FLUSH_LIMIT: usize = 4 * PAGE_SIZE;
 
 #[naked]
 pub(crate) unsafe extern "C" fn trap_vec() {
@@ -228,7 +228,7 @@ pub fn msoft_rfence_handler() {
             },
             RFenceType::SFenceVma => {
                 // If the flush size is greater than the maximum limit then simply flush all
-                if (ctx.start_addr == 0 && ctx.size == 0) || (ctx.size == usize::MAX) || (ctx.size > TLB_FLUASH_LIMIT) {
+                if (ctx.start_addr == 0 && ctx.size == 0) || (ctx.size == usize::MAX) || (ctx.size > TLB_FLUSH_LIMIT) {
                     unsafe { asm!("sfence.vma"); }
                 } else {
                     for offset in (0..ctx.size).step_by(PAGE_SIZE) {
@@ -242,7 +242,7 @@ pub fn msoft_rfence_handler() {
             RFenceType::SFenceVmaAsid => {
                 let asid = ctx.asid;
                 // If the flush size is greater than the maximum limit then simply flush all
-                if (ctx.start_addr == 0 && ctx.size == 0) || (ctx.size == usize::MAX) || (ctx.size > TLB_FLUASH_LIMIT) {
+                if (ctx.start_addr == 0 && ctx.size == 0) || (ctx.size == usize::MAX) || (ctx.size > TLB_FLUSH_LIMIT) {
                     unsafe { asm!("sfence.vma {}, {}", in(reg) 0, in(reg) asid); }
                 } else {
                     for offset in (0..ctx.size).step_by(PAGE_SIZE) {


### PR DESCRIPTION
# Description
This pull request implements the following features.
- Add sfence.vma flush range limit to prevent sfence.vma refresh time from being too long and causing system block.