### PR TITLE
feat(prototyper): add queue for fence event

### DIFF
--- a/prototyper/src/clint.rs
+++ b/prototyper/src/clint.rs
@@ -10,8 +10,11 @@ use rustsbi::SbiRet;
 
 use crate::hsm::remote_hsm;
 use crate::riscv_spec::{current_hartid, stimecmp};
+use crate::trap_stack::ROOT_STACK;
 
 pub(crate) static SIFIVECLINT: AtomicPtr<SifiveClint> = AtomicPtr::new(null_mut());
+pub(crate) const IPI_TYPE_SSOFT: u8 = 1 << 0;
+pub(crate) const IPI_TYPE_FENCE: u8 = 1 << 1;
 
 pub(crate) fn init(base: usize) {
     SIFIVECLINT.store(base as _, Release);
@@ -94,13 +97,63 @@ impl<'a> rustsbi::Ipi for ClintDevice<'a> {
     fn send_ipi(&self, hart_mask: rustsbi::HartMask) -> SbiRet {
         for hart_id in 0..=self.max_hart_id {
             if hart_mask.has_bit(hart_id) && remote_hsm(hart_id).unwrap().allow_ipi() {
-                if hart_id == current_hartid() {
-                    unsafe { riscv::register::mip::set_ssoft(); }
-                } else {
-                    unsafe { (*self.clint.load(Relaxed)).set_msip(hart_id); }
+                let old_ipi_type = set_ipi_type(hart_id, crate::clint::IPI_TYPE_SSOFT);
+                if old_ipi_type == 0 {
+                    unsafe {
+                        (*self.clint.load(Relaxed)).set_msip(hart_id);
+                    }
                 }
             }
         }
         SbiRet::success(0)
+    }
+}
+
+impl<'a> ClintDevice<'a> {
+    #[inline]
+    pub fn send_ipi_by_fence(
+        &self,
+        hart_mask: rustsbi::HartMask,
+        ctx: crate::rfence::RFenceCTX,
+    ) -> SbiRet {
+        for hart_id in 0..=self.max_hart_id {
+            if hart_mask.has_bit(hart_id) && remote_hsm(hart_id).unwrap().allow_ipi() {
+                crate::rfence::remote_rfence(hart_id).unwrap().set(ctx);
+                crate::rfence::local_rfence().add();
+                if hart_id == current_hartid() {
+                    continue;
+                }
+                let old_ipi_type = set_ipi_type(hart_id, crate::clint::IPI_TYPE_FENCE);
+                if old_ipi_type == 0 {
+                    unsafe {
+                        (*self.clint.load(Relaxed)).set_msip(hart_id);
+                    }
+                }
+            }
+        }
+        while crate::rfence::local_rfence().is_zero() == false {
+            crate::trap::rfence_signle_handler();
+        }
+        SbiRet::success(0)
+    }
+}
+
+pub fn set_ipi_type(hart_id: usize, event_id: u8) -> u8 {
+    unsafe {
+        ROOT_STACK
+            .get_unchecked_mut(hart_id)
+            .hart_context()
+            .ipi_type
+            .fetch_or(event_id, Relaxed)
+    }
+}
+
+pub fn get_and_reset_ipi_type() -> u8 {
+    unsafe {
+        ROOT_STACK
+            .get_unchecked_mut(current_hartid())
+            .hart_context()
+            .ipi_type
+            .swap(0, Relaxed)
     }
 }

--- a/prototyper/src/fifo.rs
+++ b/prototyper/src/fifo.rs
@@ -1,0 +1,65 @@
+use core::fmt::Debug;
+use core::mem::MaybeUninit;
+
+const FIFO_SIZE: usize = 16;
+
+pub enum FifoError {
+    EmptyFifo,
+    NoChange,
+}
+
+pub struct Fifo<T: Copy + Clone> {
+    data: [MaybeUninit<T>; FIFO_SIZE],
+    size: usize,
+    avil: usize,
+    tail: usize,
+}
+
+impl<T: Copy + Clone> Fifo<T> {
+    pub fn new() -> Fifo<T> {
+        let data: [MaybeUninit<T>; FIFO_SIZE] = [const { MaybeUninit::uninit() }; FIFO_SIZE];
+        Fifo {
+            data,
+            size: FIFO_SIZE,
+            avil: 0,
+            tail: 0,
+        }
+    }
+    pub fn is_full(&self) -> bool {
+        return self.avil == self.size;
+    }
+    pub fn is_empty(&self) -> bool {
+        return self.avil == 0;
+    }
+
+    pub fn push(&mut self, new_element: T) -> Result<(), FifoError> {
+        if self.is_full() {
+            return Err(FifoError::NoChange);
+        }
+        self.data[self.tail].write(new_element);
+        self.tail += 1;
+        self.avil += 1;
+        if self.tail >= self.size {
+            self.tail -= self.size;
+        }
+
+        Ok(())
+    }
+
+    pub fn pop(&mut self) -> Result<T, FifoError> {
+        if self.is_empty() {
+            return Err(FifoError::EmptyFifo);
+        }
+        let raw_head = self.tail as isize - self.avil as isize;
+        let head = if raw_head < 0 {
+            raw_head + self.size as isize
+        } else {
+            raw_head
+        } as usize;
+
+        self.avil -= 1;
+        let result = unsafe { self.data[head].assume_init_ref() }.clone();
+        unsafe { self.data[head].assume_init_drop() }
+        Ok(result)
+    }
+}

--- a/prototyper/src/hart_context.rs
+++ b/prototyper/src/hart_context.rs
@@ -4,14 +4,15 @@ use fast_trap::FlowContext;
 use crate::hsm::HsmCell;
 use crate::rfence::RFenceCell;
 use crate::NextStage;
-
+use core::sync::atomic::AtomicU8;
 
 /// 硬件线程上下文。
 pub(crate) struct HartContext {
     /// 陷入上下文。
     trap: FlowContext,
     pub hsm: HsmCell<NextStage>,
-    pub rfence: RFenceCell
+    pub rfence: RFenceCell,
+    pub ipi_type: AtomicU8,
 }
 
 impl HartContext {

--- a/prototyper/src/main.rs
+++ b/prototyper/src/main.rs
@@ -13,6 +13,7 @@ mod console;
 mod dt;
 mod dynamic;
 mod fail;
+mod fifo;
 mod hart_context;
 mod hsm;
 mod reset;


### PR DESCRIPTION
This pull request implements the following features:

- Use queue to buffer rfence events.
- Add ipi_type for msoft identification.
- Ensure the fence is synchronized.