### PR TITLE
feat(board): Add support for T-Head Clint device in RustSBI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "spin",
  "uart16550",
  "uart_xilinx",
+ "volatile-register",
 ]
 
 [[package]]

--- a/prototyper/Cargo.toml
+++ b/prototyper/Cargo.toml
@@ -23,6 +23,7 @@ uart16550 = "0.0.1"
 riscv-decode = "0.2.1"
 fast-trap = { version = "0.0.1", features = ["riscv-m"] }
 uart_xilinx = { git = "https://github.com/duskmoon314/uart-rs/" }
+volatile-register = "0.2.2"
 
 
 [[bin]]

--- a/prototyper/src/firmware/payload.rs
+++ b/prototyper/src/firmware/payload.rs
@@ -10,7 +10,6 @@ use super::{BootHart, BootInfo};
 pub fn is_boot_hart(_nonstandard_a2: usize) -> bool {
     static GENESIS: AtomicBool = AtomicBool::new(true);
     GENESIS.swap(false, Ordering::AcqRel)
-
 }
 
 pub fn get_boot_info(_nonstandard_a2: usize) -> BootInfo {

--- a/xtask/src/prototyper.rs
+++ b/xtask/src/prototyper.rs
@@ -21,11 +21,12 @@ pub struct PrototyperArg {
 }
 
 #[must_use]
+#[rustfmt::skip]
 pub fn run(arg: &PrototyperArg) -> Option<ExitStatus> {
     let arch = "riscv64imac-unknown-none-elf";
     let fdt = arg.fdt.clone();
     let payload = arg.payload.clone();
-
+    
     cargo::Cargo::new("build")
         .package("rustsbi-prototyper")
         .target(arch)


### PR DESCRIPTION
- Introduce ClintDevice enum to support multiple Clint implementations
- Modify sbi_ipi_init to dynamically select Clint device based on device tree
- Add THeadClint struct with basic register access methods
- Update Board and SBI structure to use ClintDevice

ref: https://github.com/guttatus/xuantie/blob/clint/src/peripheral/clint.rs
Signed-off-by: Zongyao Chen solar1s@163.com