### PR TITLE
feat(xtask): add xtask log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a01ba40421eca6c4f1afcedd8465fba6d9e5ef8e0e13060d0141e4cded4ab4a"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,17 +58,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +89,16 @@ checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84"
+dependencies = [
+ "clap",
+ "log",
 ]
 
 [[package]]
@@ -166,19 +156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "fast-trap"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,34 +168,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "libc"
-version = "0.2.169"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "lock_api"
@@ -235,12 +188,6 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
-
-[[package]]
-name = "memchr"
-version = "2.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "naked-function"
@@ -282,16 +229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad606bf31d67b0e10a161b7df7d6a97dda7be22ce4bebcff889476e867c9b7a"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,12 +236,6 @@ checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -324,35 +255,6 @@ dependencies = [
  "log",
  "spin",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "riscv"
@@ -588,15 +490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "uart16550"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,37 +530,6 @@ checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -747,8 +609,8 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "clap-verbosity-flag",
  "log",
- "pretty_env_logger",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a01ba40421eca6c4f1afcedd8465fba6d9e5ef8e0e13060d0141e4cded4ab4a"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +64,17 @@ checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
  "windows-sys",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -146,6 +166,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "fast-trap"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,10 +191,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "libc"
+version = "0.2.169"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "lock_api"
@@ -178,6 +235,12 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "naked-function"
@@ -219,6 +282,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad606bf31d67b0e10a161b7df7d6a97dda7be22ce4bebcff889476e867c9b7a"
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger",
+ "log",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +299,12 @@ checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -245,6 +324,35 @@ dependencies = [
  "log",
  "spin",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "riscv"
@@ -480,6 +588,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "uart16550"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +637,37 @@ checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -599,6 +747,8 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "log",
+ "pretty_env_logger",
 ]
 
 [[package]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,4 +8,4 @@ repository.workspace = true
 [dependencies]
 clap = { version = "4.5.4", features = ["derive", "env", "suggestions"] }
 log = "0.4.21"
-pretty_env_logger = "0.4"
+clap-verbosity-flag = "3.0.2"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,3 +7,5 @@ repository.workspace = true
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive", "env", "suggestions"] }
+log = "0.4.21"
+pretty_env_logger = "0.4"

--- a/xtask/src/bench.rs
+++ b/xtask/src/bench.rs
@@ -25,6 +25,7 @@ pub fn run(arg: &BenchArg) -> Option<ExitStatus> {
         .join(arch)
         .join("release");
 
+    info!("Building bench kernel");
     cargo::Cargo::new("build")
         .package("rustsbi-bench-kernel")
         .target(arch)
@@ -32,6 +33,7 @@ pub fn run(arg: &BenchArg) -> Option<ExitStatus> {
         .status()
         .ok()?;
 
+    info!("Copy to binary");
     let exit_status = Command::new("rust-objcopy")
         .args(["-O", "binary"])
         .arg("--binary-architecture=riscv64")
@@ -41,6 +43,7 @@ pub fn run(arg: &BenchArg) -> Option<ExitStatus> {
         .ok()?;
 
     if arg.pack {
+        info!("Pack to image");
         match fs::exists(target_dir.join("rustsbi-prototyper.bin")) {
             Ok(true) => {}
             Ok(false) => {

--- a/xtask/src/logger.rs
+++ b/xtask/src/logger.rs
@@ -1,0 +1,55 @@
+use log::Level;
+use std::io::Write;
+
+use crate::Cli;
+
+/// Simple logger implementation for RustSBI that supports colored output.
+pub struct Logger;
+
+impl Logger {
+    /// Initialize the logger with log level from RUST_LOG env var or default to Info.
+    pub fn init(cli: &Cli) -> Result<(), log::SetLoggerError> {
+        // Set max log level from parmas env var if present, otherwise use Info
+        log::set_max_level(cli.verbose.log_level_filter());
+        log::set_logger(&Logger)
+    }
+}
+
+impl log::Log for Logger {
+    // Always enable logging for all log levels
+    #[inline]
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        true
+    }
+
+    // Log messages with color-coded levels
+    #[inline]
+    fn log(&self, record: &log::Record) {
+        // ANSI color codes for different log levels
+        const ERROR_COLOR: u8 = 31; // Red
+        const WARN_COLOR: u8 = 93; // Bright yellow
+        const INFO_COLOR: u8 = 32; // Green
+        const DEBUG_COLOR: u8 = 36; // Cyan
+        const TRACE_COLOR: u8 = 90; // Bright black
+
+        let color_code = match record.level() {
+            Level::Error => ERROR_COLOR,
+            Level::Warn => WARN_COLOR,
+            Level::Info => INFO_COLOR,
+            Level::Debug => DEBUG_COLOR,
+            Level::Trace => TRACE_COLOR,
+        };
+
+        eprintln!(
+            "\x1b[1;37m[RustSBI-xtask] \x1b[1;{color_code}m{:^5}\x1b[0m - {}",
+            record.level(),
+            record.args(),
+        );
+    }
+
+    // No-op flush since we use println! which is already line-buffered
+    #[inline]
+    fn flush(&self) {
+        std::io::stderr().flush().expect("Unable to flush stderr");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,13 +1,14 @@
 use clap::{Parser, Subcommand};
+use clap_verbosity_flag::{InfoLevel, Verbosity};
 use std::process::ExitCode;
 
 #[macro_use]
 mod utils;
 mod bench;
+mod logger;
 mod prototyper;
 mod test;
 
-extern crate pretty_env_logger;
 #[macro_use]
 extern crate log;
 
@@ -24,6 +25,8 @@ use crate::test::TestArg;
 struct Cli {
     #[clap(subcommand)]
     cmd: Cmd,
+    #[command(flatten)]
+    verbose: Verbosity<InfoLevel>,
 }
 
 #[derive(Subcommand)]
@@ -34,8 +37,10 @@ enum Cmd {
 }
 
 fn main() -> ExitCode {
-    pretty_env_logger::init();
-    if let Some(code) = match Cli::parse().cmd {
+    let cli_args = Cli::parse();
+    logger::Logger::init(&cli_args).expect("Unable to init logger");
+
+    if let Some(code) = match cli_args.cmd {
         Cmd::Prototyper(ref arg) => prototyper::run(arg),
         Cmd::Test(ref arg) => test::run(arg),
         Cmd::Bench(ref arg) => bench::run(arg),
@@ -45,6 +50,7 @@ fn main() -> ExitCode {
             return ExitCode::SUCCESS;
         }
     }
+
     error!("Failed to run task!");
     ExitCode::FAILURE
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,6 +7,10 @@ mod bench;
 mod prototyper;
 mod test;
 
+extern crate pretty_env_logger;
+#[macro_use]
+extern crate log;
+
 use crate::bench::BenchArg;
 use crate::prototyper::PrototyperArg;
 use crate::test::TestArg;
@@ -30,14 +34,17 @@ enum Cmd {
 }
 
 fn main() -> ExitCode {
+    pretty_env_logger::init();
     if let Some(code) = match Cli::parse().cmd {
         Cmd::Prototyper(ref arg) => prototyper::run(arg),
         Cmd::Test(ref arg) => test::run(arg),
         Cmd::Bench(ref arg) => bench::run(arg),
     } {
         if code.success() {
+            info!("Finished");
             return ExitCode::SUCCESS;
         }
     }
+    error!("Failed to run task!");
     ExitCode::FAILURE
 }

--- a/xtask/src/prototyper.rs
+++ b/xtask/src/prototyper.rs
@@ -18,6 +18,9 @@ pub struct PrototyperArg {
 
     #[clap(long, env = "PROTOTYPER_PAYLOAD_PATH")]
     pub payload: Option<String>,
+
+    #[clap(long, default_value = "INFO")]
+    pub log_level: String,
 }
 
 #[must_use]
@@ -42,13 +45,14 @@ pub fn run(arg: &PrototyperArg) -> Option<ExitStatus> {
         .env("RUSTFLAGS", "-C relocation-model=pie -C link-arg=-pie")
         .features(&arg.features)
         .optional(arg.fdt.is_some(), |cargo| {
-            export_env!("PROTOTYPER_FDT_PATH" ?= fdt.unwrap());
+            cargo.env("PROTOTYPER_FDT_PATH", fdt.as_ref().unwrap());
             cargo.features(["fdt".to_string()])
         })
         .optional(payload.is_some(), |cargo| {
-            export_env!("PROTOTYPER_PAYLOAD_PATH" ?= payload.unwrap());
+            cargo.env("PROTOTYPER_PAYLOAD_PATH", payload.as_ref().unwrap());
             cargo.features(["payload".to_string()])
         })
+        .env("RUST_LOG", &arg.log_level)
         .release()
         .status()
         .ok()?;

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -25,6 +25,7 @@ pub fn run(arg: &TestArg) -> Option<ExitStatus> {
         .join(arch)
         .join("release");
 
+    info!("Building test kernel");
     cargo::Cargo::new("build")
         .package("rustsbi-test-kernel")
         .target(arch)
@@ -32,6 +33,7 @@ pub fn run(arg: &TestArg) -> Option<ExitStatus> {
         .status()
         .ok()?;
 
+    info!("Copy to binary");
     let exit_status = Command::new("rust-objcopy")
         .args(["-O", "binary"])
         .arg("--binary-architecture=riscv64")
@@ -41,6 +43,7 @@ pub fn run(arg: &TestArg) -> Option<ExitStatus> {
         .ok()?;
 
     if arg.pack {
+        info!("Pack to image");
         match fs::exists(target_dir.join("rustsbi-prototyper.bin")) {
             Ok(true) => {}
             Ok(false) => {

--- a/xtask/src/utils/envs.rs
+++ b/xtask/src/utils/envs.rs
@@ -1,3 +1,4 @@
+#[allow(unused)]
 macro_rules! export_env {
     ($env:literal ?= $val:expr) => {
         if std::env::vars_os().all(|(k, _)| k != $env) {


### PR DESCRIPTION
When running `xtask`, the return value of `main` is silently ignored, and the process always exits with code 0. As a result, it becomes impossible to determine what happened during execution.

This pull request introduces `clap-verbosity-flag` to control log level of xtask and adds log output for the build helper. 

Also, the log level of prototyper will not depend on `RUST_LOG` env when you running `cargo prototyper` to build it, you should use `cargo prototyper --log-level INFO`.