### PR TITLE
fix(prototyper): use `already_available` when target hart is already started in HSM extension

### DIFF
--- a/prototyper/src/sbi/hsm.rs
+++ b/prototyper/src/sbi/hsm.rs
@@ -200,7 +200,7 @@ impl rustsbi::Hsm for SbiHsm {
                     }
                     SbiRet::success(0)
                 } else {
-                    SbiRet::already_started()
+                    SbiRet::already_available()
                 }
             }
             None => SbiRet::invalid_param(),


### PR DESCRIPTION
In the RISC-V SBI Specification, it shows that in HSM `hart_start` function, error code `SBI_ERR_ALREADY_AVAILABLE` represents 'the given hartid is already started'. The `SBI_ERR_ALREADY_STARTED` error code is used instead when a PMU counter or an SSE software event is already started.

![图片](https://github.com/user-attachments/assets/e07abc64-0081-451e-b3f6-f838f9c6ebba)

Ref: https://github.com/riscv-non-isa/riscv-sbi-doc/blob/master/src/ext-hsm.adoc#function-hart-start-fid-0